### PR TITLE
Feld verstecken.

### DIFF
--- a/ytemplates/bootstrap/value.spam_protection.tpl.php
+++ b/ytemplates/bootstrap/value.spam_protection.tpl.php
@@ -12,15 +12,16 @@
         value="0" readonly="readonly" tabindex="-1">
     <style>
         [id="<?=$this->getHTMLId() ?>"] {
-            overflow: hidden;
-            height: 1px;
-            opacity: 1;
-	    padding-top: 1px;
-        }
-        [id="<?=$this->getHTMLId() ?>"] input {
-		background-color: transparent; 
-		border-color: transparent;
-        }
+ 		position: absolute !important;
+		width: 1px !important;
+		height: 1px !important;
+		padding: 0 !important;
+		margin: -1px !important;
+		overflow: hidden !important;
+		clip: rect(0, 0, 0, 0) !important;
+		white-space: nowrap !important;
+		border: 0 !important;
+	    }
     </style>
     <script type="text/javascript">
         var date = new Date();

--- a/ytemplates/bootstrap/value.spam_protection.tpl.php
+++ b/ytemplates/bootstrap/value.spam_protection.tpl.php
@@ -15,6 +15,7 @@
             overflow: hidden;
             height: 1px;
             opacity: 1;
+	    padding-top: 1px;
         }
         [id="<?=$this->getHTMLId() ?>"] input {
 		background-color: transparent; 


### PR DESCRIPTION
Box-Shaddow und andere Spielereien sind vermutlich auch bei 1px Höhe noch zu sehen. Mit padding-top (in verbindung mit background-color: transparent) sollte alles verschwinden.