### PR TITLE
Fix für #29

### DIFF
--- a/lib/yform/value/spam_protection.php
+++ b/lib/yform/value/spam_protection.php
@@ -8,7 +8,7 @@ class rex_yform_value_spam_protection extends rex_yform_value_abstract
 
         $debug = (int)$this->getElement(4);
         $session_timestamp_key = "spamfilter".$this->params["form_name"];
-        $session_timestamp = rex_request::session($session_timestamp_key);
+        $session_timestamp = rex_request::session($session_timestamp_key, 'int', 0);
         $form_timestamp = rex_request($this->getFieldId()."_microtime", 'int', false);
         $js_enabled = rex_request($this->getFieldId()."_js_enabled", 'int', false);
 


### PR DESCRIPTION
Siehe https://github.com/FriendsOfREDAXO/yform_spam_protection/issues/29. Entfernt die Warnung.