### PR TITLE
IP Whitelist and ignore logged-in users features added

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -24,3 +24,7 @@ yform_spam_protection_tld_list = Top-Level-Domains
 yform_spam_protection_tld_list_notice = Top-Level-Domains, an die kein Versand erfolgen soll, bspw. <code>.ru</code>
 yform_spam_protection_activate = Aktivieren
 yform_spam_protection_deactivate = Deaktivieren
+yform_spam_protection_ip_whitelist = IP Whitelist
+yform_spam_protection_ip_whitelist_notice = Liste von IPs die nicht blockiert werden sollen. IPs mit Komma trennen.
+yform_spam_protection_ignore_user = Eingeloggt Benutzer ignorieren
+yform_spam_protection_ignore_user_notice = Ignoriert Benutzer die im Redaxo Backend eingeloggt sind.

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -24,3 +24,7 @@ yform_spam_protection_tld_list = Top-Level-Domains
 yform_spam_protection_tld_list_notice = Top-Level-Domains, an die kein Versand erfolgen soll, bspw. <code>.ru</code>
 yform_spam_protection_activate = Activate
 yform_spam_protection_deactivate = Deactivate
+yform_spam_protection_ip_whitelist = IP Whitelist
+yform_spam_protection_ip_whitelist_notice = List of IPs that should not be blocked. Separate IPs with comma.
+yform_spam_protection_ignore_user = Ignore logged in user
+yform_spam_protection_ignore_user_notice = Ignores users who are logged into the Redaxo backend.

--- a/pages/yform.spam_protection.settings.php
+++ b/pages/yform.spam_protection.settings.php
@@ -84,6 +84,18 @@ if (rex::getUser()->isAdmin()) {
     // $field->setNotice($this->i18n('tld_list_notice'));
     // $field->setAttribute('disabled', true);
 
+    $field = $form->addTextField('ip_whitelist');
+    $field->setLabel($this->i18n('ip_whitelist'));
+    $field->setNotice($this->i18n('ip_whitelist_notice'));
+
+    $field = $form->addSelectField('ignore_user');
+    $field->setLabel($this->i18n('ignore_user'));
+    $field->setNotice($this->i18n('ignore_user_notice'));
+    $select = $field->getSelect();
+    $select->setSize(1);
+    $select->addOption($this->i18n('activate'), 1);
+    $select->addOption($this->i18n('deactivate'), 0);
+
     $fragment = new rex_fragment();
     $fragment->setVar('class', 'edit', false);
     $fragment->setVar('title', $this->i18n('title'), false);


### PR DESCRIPTION
Wie in https://github.com/FriendsOfREDAXO/yform_spam_protection/issues/45 angeregt: es kann einen IP Whitelist geführt werden und es kann aktiviert werden, dass ein eingeloggter Redaxo Benutzer ignoriert wird.
