### PR TITLE
YForm 5.0 ermöglichen

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,12 +1,12 @@
 package: yform_spam_protection
-version: '1.2.6'
+version: '1.3.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/friendsofredaxo/yform_spam_protection
 perm: admin[]
 requires:
     redaxo: '^5.17'
     packages:
-        yform: '^4'
+        yform: '>=4'
     php:
         version: '>=8.1'
 

--- a/package.yml
+++ b/package.yml
@@ -1,16 +1,12 @@
 package: yform_spam_protection
-<<<<<<< yform5
 version: '1.3.0'
-=======
-version: '1.2.7'
->>>>>>> main
 author: Friends Of REDAXO
 supportpage: https://github.com/friendsofredaxo/yform_spam_protection
 perm: admin[]
 requires:
     redaxo: '^5.17'
     packages:
-        yform: '>=4'
+        yform: '>=4,<6'
     php:
         version: '>=8.1'
 


### PR DESCRIPTION
Erweiterung der nötigen Voraussetzungen von nur YForm 4 auf auch YForm 5.

Ansonsten erscheint mir dieses Addon unbedenklich zu sein. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.3.0.
  * Relaxed the version requirement for the yform dependency to allow version 4 or higher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->